### PR TITLE
Altering fixture scope of `fake_comic` to "function"

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,7 +36,7 @@ def fake_metadata():
     return meta_data
 
 
-@pytest.fixture(scope="module")
+@pytest.fixture(scope="function")
 def fake_comic(tmp_path_factory):
     test_dir = tmp_path_factory.mktemp("data")
     img_1 = test_dir / "image-1.jpg"


### PR DESCRIPTION
This PR aims to improve test reliability of test `test_sort_comic` by altering fixture scope of `fake_comic` to "function".

The test can fail in this way by running `pip3 install pytest-repeat; python3 -m pytest --count=2 tests/test_taggerlib_filesorter.py::test_sort_comic`:

```
        # Write metadata to fake file
        comic = ComicArchive(fake_comic)
        if comic.has_metadata():
            comic.remove_metadata()
>       comic.write_metadata(fake_metadata)

tests/test_taggerlib_filesorter.py:37: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
../../.local/lib/python3.8/site-packages/darkseid/comicarchive.py:276: in write_metadata
    write_success = self.archiver.write_archive_file(
../../.local/lib/python3.8/site-packages/darkseid/comicarchive.py:70: in write_archive_file
    self.rebuild_zipfile([archive_file])
../../.local/lib/python3.8/site-packages/darkseid/comicarchive.py:106: in rebuild_zipfile
    zin = zipfile.ZipFile(self.path, "r")
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
    def __init__(self, file, mode="r", compression=ZIP_STORED, allowZip64=True,
        ...    
        # Check if we were passed a file-like object
        if isinstance(file, os.PathLike):
            file = os.fspath(file)
        if isinstance(file, str):
            # No, it's a filename
            self._filePassed = 0
            self.filename = file
            modeDict = {'r' : 'rb', 'w': 'w+b', 'x': 'x+b', 'a' : 'r+b',
                        'r+b': 'w+b', 'w+b': 'wb', 'x+b': 'xb'}
            filemode = modeDict[mode]
            while True:
                try:
>                   self.fp = io.open(file, filemode)
E                   FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pytest-of-ailen/pytest-22/comic0/Aquaman v1 #001 (of 08) (1994).cbz'
```

It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
