### PR TITLE
Add Sweet Shop filename support to _clean_series_name

### DIFF
--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -8,6 +8,7 @@ __all__ = [
 ]
 
 import platform
+import re
 from logging import getLogger
 from os import environ
 from pathlib import Path, PurePath
@@ -114,7 +115,13 @@ def _clean_series_name(name: str) -> str:
     for old, new in replacements.items():
         cleaned = cleaned.replace(old, new)
 
-    return cleaned.strip()
+    # Handle Sweet Shop filenames (e.g. "radiant-black-issue-1" → "radiant black").
+    sweet_shop_pattern = re.compile(r"[-\s]+issue[-\s]+\d+.*", re.IGNORECASE)
+    if sweet_shop_pattern.search(cleaned):
+        cleaned = sweet_shop_pattern.sub("", cleaned)
+        cleaned = cleaned.replace("-", " ")
+
+    return " ".join(cleaned.split())
 
 
 def _clean_issue_number(number: Any) -> str:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -26,6 +26,10 @@ from metrontagger.utils import cleanup_string, create_query_params
         ({"series_id": "202", "issue": "é"}, {"series_id": "202", "number": "%C3%A9"}),
         # Edge case: series name only, no issue
         ({"series": "X-Men"}, {"series_name": "X-Men", "number": "1"}),
+        # Sweet Shop: single-word series slug
+        ({"series": "criminal-issue-1"}, {"series_name": "criminal", "number": "1"}),
+        # Sweet Shop: multi-word series slug
+        ({"series": "radiant-black-issue-1"}, {"series_name": "radiant black", "number": "1"}),
         # Edge case: issue is "0" (should become "0")
         ({"series_id": "303", "issue": "0"}, {"series_id": "303", "number": "0"}),
         # Edge case: issue is "000" (should become "0")
@@ -48,6 +52,8 @@ from metrontagger.utils import cleanup_string, create_query_params
         "issue_leading_zeros",
         "unicode_issue_number",
         "series_name_only",
+        "sweet_shop_single_word",
+        "sweet_shop_multi_word",
         "issue_zero",
         "issue_all_zeros",
         "issue_single_leading_zero",


### PR DESCRIPTION
- Sweet Shop filenames use a URL-slug format (e.g. radiant-black-issue-1.pdf) that comicfn2dict cannot parse, leaving the issue number embedded in the series name.
- Strip the -issue-N suffix and convert remaining hyphens to spaces so the series name resolves correctly for search queries.