### PR TITLE
Remove redundant " - " replacement from _clean_series_name

### DIFF
--- a/metrontagger/utils.py
+++ b/metrontagger/utils.py
@@ -102,7 +102,6 @@ def _clean_series_name(name: str) -> str:
 
     # Define replacements for better maintainability
     replacements = {
-        " - ": " ",
         ",": "",
         " & ": " ",
         "HC": "",

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,10 +10,10 @@ from metrontagger.utils import cleanup_string, create_query_params
         ({"series_id": "123", "issue": "005"}, {"series_id": "123", "number": "5"}),
         # Happy path: series_id present, issue missing
         ({"series_id": "456"}, {"series_id": "456", "number": "1"}),
-        # Happy path: series name with hyphens, commas, ampersands, and keywords
+        # Happy path: series name with commas, ampersands, and keywords
         (
             {
-                "series": "Batman - Detective Comics, Vol. 1 & 2 HC TPB Digital Chapter",
+                "series": "Batman Detective Comics, Vol. 1 & 2 HC TPB Digital Chapter",
                 "issue": "001",
             },
             {"series_name": "Batman Detective Comics Vol. 1 2", "number": "1"},


### PR DESCRIPTION
## Summary

- `comicfn2dict` already handles ` - ` in filenames by splitting on it and placing the second part into the `title` key, so the `series` value it returns will never contain ` - `
- Removes the now-redundant `" - ": " "` entry from the replacements dict in `_clean_series_name`
- Updates the corresponding test to reflect that ` - ` won't appear in a series name coming from `comicfn2dict`
