### PR TITLE
Fix comic renaming failure caused by malformed MetronInfo.xml (darkseid 8.3.0)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
   "pandas>=2.3.3",
   "comicfn2dict>=0.3.1",
   "tqdm>=4.67.3",
-  "darkseid>=8.2.0",
+  "darkseid>=8.3.0",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -561,7 +561,7 @@ toml = [
 
 [[package]]
 name = "darkseid"
-version = "8.2.0"
+version = "8.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "defusedxml" },
@@ -571,9 +571,9 @@ dependencies = [
     { name = "xmlschema" },
     { name = "zipremove" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/17/13/36e9512454e54162b3d2baeaf9e72225068de52002c53d724d4e42da7e72/darkseid-8.2.0.tar.gz", hash = "sha256:a6795f044e89fc93e5fa3ce76421aa39f9a08f08359e5b93c6e6f4a187e2b3d4", size = 115085, upload-time = "2026-07-13T12:47:04.603Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/96/4db8fc69629ef931ef6f9706a655887310970b3d00961e74229b85786b59/darkseid-8.3.0.tar.gz", hash = "sha256:c826b9b76efdd9dc3484e965f801973316274c23966dd927496b7cfb8d072826", size = 115987, upload-time = "2026-07-19T18:52:32.17Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/3b/40c5c3c8f9550278c8d459b001614a4dea72d2b89d0c8131aaef8825ae4e/darkseid-8.2.0-py3-none-any.whl", hash = "sha256:5783581219ae351a890fd651373b929c8ed6d14c7dda1a77b4e8025a4e480b31", size = 94112, upload-time = "2026-07-13T12:47:03.31Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/64/13cf32f78bde45b007f19841663c00f66dbd16c256f6c7eeaa9b44c865a3/darkseid-8.3.0-py3-none-any.whl", hash = "sha256:d60c4e29136cd03071f719273e705bc9ceacd8ec8fb596e6113c008f9016b8bb", size = 94601, upload-time = "2026-07-19T18:52:31.103Z" },
 ]
 
 [[package]]
@@ -815,7 +815,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "comicfn2dict", specifier = ">=0.3.1" },
-    { name = "darkseid", specifier = ">=8.2.0" },
+    { name = "darkseid", specifier = ">=8.3.0" },
     { name = "imagehash", specifier = ">=4.3.2" },
     { name = "mokkari", specifier = ">=4.0.0" },
     { name = "pandas", specifier = ">=2.3.3" },


### PR DESCRIPTION
## Problem

Renaming comics via `metron-tagger --rename` could silently produce garbage filenames (e.g. `Unknown %format% v0 (Unknown).cbz`) instead of an error, for any comic whose embedded `MetronInfo.xml` had previously been re-written by metron-tagger.

Root cause: a bug in `darkseid`'s `MetronInfo._get_root()` could write a `MetronInfo.xml` with **duplicate `xmlns:xsi` / `xsi:schemaLocation` attributes** on the root element — invalid XML per the XML spec. Once written, that file could no longer be parsed. Older darkseid versions swallowed the resulting `ParseError` and silently returned an empty `Metadata()` object, which `metron-tagger` then used to build a filename, with no error surfaced to the user.

## Fix

Bump the `darkseid` dependency to `>=8.3.0`, which fixes the duplicate-attribute bug on write.

## ⚠️ Action required for existing users

This fix only prevents the corruption going forward — it does not repair files that are **already** corrupted on disk. If you tagged comics with metron-tagger 4.10.3 and the embedded `MetronInfo.xml` was re-written (e.g. by re-tagging an already-tagged comic), that file's `MetronInfo.xml` may already contain the duplicate attributes and will still fail to parse after this update.

**Users upgrading from metron-tagger 4.10.3 should:**
1. Run `metron-tagger -m --validate /path/to/comics` to identify the comics effected.
2. Run `metron-tagger -dm /path/to/comics/foo_bar.cbz` to remove the existing `MetronInfo.xml` from any comic that had invalid `MetronInfo.xml`.
3. Run `metron-tagger -om --ignore-existing /path/to/comics` to re-tag the comic so a valid `MetronInfo.xml` is written.