### PR TITLE
Report daily API rate limit remaining after tagging

### DIFF
--- a/metrontagger/talker.py
+++ b/metrontagger/talker.py
@@ -257,6 +257,19 @@ class UIPresenter:
         questionary.print(f"\n{fn.name} - Results found:", style=Styles.TITLE)
 
     @staticmethod
+    def print_rate_limit_status(
+        remaining: int | None, limit: int | None, reset: datetime | None
+    ) -> None:
+        """Print the sustained (daily) Metron API quota remaining, if known."""
+        if not isinstance(remaining, int) or not isinstance(limit, int):
+            return
+
+        msg = f"Metron API: {remaining:,}/{limit:,} daily requests remaining"
+        if isinstance(reset, datetime):
+            msg += f" (resets {reset.astimezone().strftime('%H:%M %Z')})"
+        questionary.print(msg, style=Styles.INFO)
+
+    @staticmethod
     def print_metadata_write_success(  # noqa: PLR0913
         formats: list[str],
         series_name: str,
@@ -826,6 +839,11 @@ class Talker:
         # Search by filename if no existing metadata or ID handling failed
         return self._search_by_filename(fn, comic, config)
 
+    def _print_rate_limit_status(self) -> None:
+        """Show the user's remaining daily (sustained) Metron API quota, if known."""
+        sustained = self.api.rate_limit_status.sustained
+        self.ui.print_rate_limit_status(sustained.remaining, sustained.limit, sustained.reset)
+
     def _post_process_matches(self) -> None:
         """Post-process the match results."""
         # Print match results summary
@@ -952,7 +970,9 @@ class Talker:
 
         # Print match results
         self._post_process_matches()
+        self._print_rate_limit_status()
 
     def retrieve_single_issue(self, id_: int, fn: Path) -> None:
         """Retrieve and write metadata for a single issue."""
         self._write_issue_md(fn, id_)
+        self._print_rate_limit_status()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,7 +40,7 @@ classifiers = [
   "Operating System :: Microsoft :: Windows",
 ]
 dependencies = [
-  "mokkari>=4.0.0",
+  "mokkari>=4.1.0",
   "questionary>=2.1.1",
   "pyxdg>=0.28",
   "imagehash>=4.3.2",

--- a/tests/test_talker.py
+++ b/tests/test_talker.py
@@ -20,6 +20,7 @@ from metrontagger.talker import (
     ProcessingConfig,
     SearchResult,
     Talker,
+    UIPresenter,
 )
 
 tzinfo = timezone(timedelta(hours=-5))
@@ -1096,6 +1097,75 @@ def test_talker_retrieve_single_issue(talker, sample_path):
     with patch.object(talker, "_write_issue_md") as mock_write:
         talker.retrieve_single_issue(123, sample_path)
         mock_write.assert_called_once_with(sample_path, 123)
+
+
+def test_talker_retrieve_single_issue_prints_rate_limit_status(talker, sample_path):
+    """Test that retrieving a single issue also reports the rate limit status."""
+    with (
+        patch.object(talker, "_write_issue_md"),
+        patch.object(talker, "_print_rate_limit_status") as mock_print_rate_limit,
+    ):
+        talker.retrieve_single_issue(123, sample_path)
+        mock_print_rate_limit.assert_called_once()
+
+
+def test_talker_identify_comics_prints_rate_limit_status(talker):
+    """Test that identify_comics reports the rate limit status after processing."""
+    args = Mock()
+    args.id = None
+
+    with (
+        patch.object(talker, "_post_process_matches"),
+        patch.object(talker, "_print_rate_limit_status") as mock_print_rate_limit,
+    ):
+        talker.identify_comics(args, [])
+        mock_print_rate_limit.assert_called_once()
+
+
+def test_talker_print_rate_limit_status(talker):
+    """Test that Talker._print_rate_limit_status reads the sustained window from the API."""
+    reset = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    talker.api.rate_limit_status.sustained.remaining = 4823
+    talker.api.rate_limit_status.sustained.limit = 5000
+    talker.api.rate_limit_status.sustained.reset = reset
+
+    with patch.object(talker.ui, "print_rate_limit_status") as mock_print:
+        talker._print_rate_limit_status()
+        mock_print.assert_called_once_with(4823, 5000, reset)
+
+
+def test_ui_presenter_print_rate_limit_status():
+    """Test that the rate limit message is printed when limit data is known."""
+    reset = datetime(2026, 7, 21, tzinfo=timezone.utc)
+    with patch("metrontagger.talker.questionary.print") as mock_print:
+        UIPresenter.print_rate_limit_status(4823, 5000, reset)
+        mock_print.assert_called_once()
+        assert "4,823/5,000 daily requests remaining" in mock_print.call_args[0][0]
+
+
+def test_ui_presenter_print_rate_limit_status_without_reset():
+    """Test that the message omits the reset time when it isn't known."""
+    with patch("metrontagger.talker.questionary.print") as mock_print:
+        UIPresenter.print_rate_limit_status(4823, 5000, None)
+        mock_print.assert_called_once()
+        msg = mock_print.call_args[0][0]
+        assert "4,823/5,000 daily requests remaining" in msg
+        assert "resets" not in msg
+
+
+@pytest.mark.parametrize(
+    ("remaining", "limit"),
+    [
+        (None, 5000),
+        (4823, None),
+        (None, None),
+    ],
+)
+def test_ui_presenter_print_rate_limit_status_unknown(remaining, limit):
+    """Test that nothing is printed when the sustained limit isn't known yet."""
+    with patch("metrontagger.talker.questionary.print") as mock_print:
+        UIPresenter.print_rate_limit_status(remaining, limit, None)
+        mock_print.assert_not_called()
 
 
 # Edge cases and error handling

--- a/uv.lock
+++ b/uv.lock
@@ -817,7 +817,7 @@ requires-dist = [
     { name = "comicfn2dict", specifier = ">=0.3.1" },
     { name = "darkseid", specifier = ">=8.3.0" },
     { name = "imagehash", specifier = ">=4.3.2" },
-    { name = "mokkari", specifier = ">=4.0.0" },
+    { name = "mokkari", specifier = ">=4.1.0" },
     { name = "pandas", specifier = ">=2.3.3" },
     { name = "py7zr", marker = "extra == '7zip'", specifier = ">=1.0.0" },
     { name = "pymupdf", marker = "extra == 'pdf'", specifier = ">=1.26.6" },
@@ -850,15 +850,15 @@ test = [
 
 [[package]]
 name = "mokkari"
-version = "4.0.1"
+version = "4.1.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pydantic" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/3d/16/5ad6c617f340265c32218846501f69996c920c8cc9461b747bb99ad3f9f5/mokkari-4.0.1.tar.gz", hash = "sha256:614556b6025866c47c1a5ed6ac10733e6724e49b76f95161ae3494b71c9877eb", size = 78140, upload-time = "2026-07-18T18:24:37.083Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/9e/8298180d8afb2337a91a94e1df2fb2fb631335f6504a86bde59d7df90c54/mokkari-4.1.0.tar.gz", hash = "sha256:12887338df161c75169338adbba9e7d96ecf8e675151aa23be8ba188ee0a2f8b", size = 78433, upload-time = "2026-07-20T18:12:15.105Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/51/cd4cc21130ad89da93fa4aad3b27f5ba82e80765f7122e6530d9eca78305/mokkari-4.0.1-py3-none-any.whl", hash = "sha256:bc805800d55d2e7c7a70b567fcbc80e03ff5ffc1a46f459b2c5e5e59a9abe98e", size = 58965, upload-time = "2026-07-18T18:24:35.918Z" },
+    { url = "https://files.pythonhosted.org/packages/57/35/bcdcb5bbf6eb228d1f67aef278870a44d0c265483c7a3324feae96e6248f/mokkari-4.1.0-py3-none-any.whl", hash = "sha256:819514b2ad23f09f128c0bcbd5972aea927add944fc14b72fede7b802c6022b4", size = 59122, upload-time = "2026-07-20T18:12:14.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bump the `mokkari` dependency to >=4.1.0, which exposes the sustained (daily) API quota via `Session.rate_limit_status`, populated from Metron's `X-RateLimit-Sustained-*` response headers.
- Surface that quota to the user after online tagging finishes (`identify_comics`) and after retrieving a single issue (`retrieve_single_issue`), e.g.: `Metron API: 4,823/5,000 daily requests remaining (resets 20:00 EDT)`.
- No message is printed if the remaining/limit values aren't known yet (e.g. no requests were made this session).
